### PR TITLE
Enhance events submitting to Gundi

### DIFF
--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -111,10 +111,14 @@ async def action_pull_events(integration:Integration, action_config: PullEventsC
     async for ob in obs:
         to_send.append(_transform_ebird_to_gundi_event(ob))
     
-    logger.info(f"Submitting {len(to_send)} eBird observations to Gundi")
-    response = await send_events_to_gundi(
+    if to_send:
+        logger.info(f"Submitting {len(to_send)} eBird observations to Gundi for integration ID: {str(integration.id)}")
+        await send_events_to_gundi(
             events=to_send,
-            integration_id=str(integration.id))
+            integration_id=str(integration.id)
+        )
+    else:
+        logger.info(f"No eBird observations to submit to Gundi for integration ID: {str(integration.id)}")
 
     return {'result': {'events_extracted': len(to_send)}}
 


### PR DESCRIPTION
This pull request includes a change to the `action_pull_events` function in the `app/actions/handlers.py` file to improve logging and handle cases where there are no events to send.

Logging improvements and handling empty events:

* [`app/actions/handlers.py`](diffhunk://#diff-f575ea29ea1c9649ccb87f9c38a0fd9a78b9f210c9e5e9d800e328ee30d08113L114-R121): Modified the `action_pull_events` function to log a message when there are no eBird observations to submit and to include the integration ID in the log message when submitting events.

![image](https://github.com/user-attachments/assets/fbfcc95e-83ff-4ee4-901c-29c16a8ff2c4)
